### PR TITLE
postgres docker-compose issue correspondence

### DIFF
--- a/laradock/docker-compose.yml
+++ b/laradock/docker-compose.yml
@@ -41,6 +41,8 @@ volumes:
     driver: ${VOLUMES_DRIVER}
   mosquitto:
     driver: ${VOLUMES_DRIVER}
+  postgres:
+    external: true
 
 services:
 
@@ -380,8 +382,10 @@ services:
     postgres:
       build: ./postgres
       volumes:
-        - ${DATA_PATH_HOST}/postgres:/var/lib/postgresql/data
-        - ${POSTGRES_ENTRYPOINT_INITDB}:/docker-entrypoint-initdb.d
+        #- ${DATA_PATH_HOST}/postgres:/var/lib/postgresql/data
+        - postgres:/var/lib/postgresql/data
+        #- ${POSTGRES_ENTRYPOINT_INITDB}:/docker-entrypoint-initdb.d
+        - ./postgres/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
       ports:
         - "${POSTGRES_PORT}:5432"
       environment:


### PR DESCRIPTION
# docker-compose upでのpostgreSQLの立ち上げ失敗について
## 問題の起こり
postgreSQLコンテナが立ち上がらなくなった

## 状況
コマンドはdocker-compose up -d postgres
コマンド実行時の出力は下記のようになる
```
$ docker-compose up -d postgres  
Creating laradock_postgres_1 ... done
```

だが、docker ps -aで確認すると下記のように表示される
```
$ docker ps -a
CONTAINER ID        IMAGE                 COMMAND                  CREATED             STATUS                      PORTS               NAMES
d6bf7adfc3de        laradock_postgres     "docker-entrypoint.s…"   10 seconds ago      Exited (1) 9 seconds ago                        laradock_postgres_1
```

コマンド実行時のlogは以下のように表示された。
``` 
$ docker-compose up postgres
Creating laradock_postgres_1 ... done
Attaching to laradock_postgres_1
postgres_1             | The files belonging to this database system will be owned by user "postgres".
postgres_1             | This user must also own the server process.
postgres_1             |
postgres_1             | The database cluster will be initialized with locale "en_US.utf8".
postgres_1             | The default database encoding has accordingly been set to "UTF8".
postgres_1             | The default text search configuration will be set to "english".
postgres_1             |
postgres_1             | Data page checksums are disabled.
postgres_1             |
postgres_1             | initdb: directory "/var/lib/postgresql/data" exists but is not empty
postgres_1             | If you want to create a new database system, either remove or empty
postgres_1             | the directory "/var/lib/postgresql/data" or run initdb
postgres_1             | with an argument other than "/var/lib/postgresql/data".
laradock_postgres_1 exited with code 1
```
## 対策
調べていると下記の記事が見つかった。
https://qiita.com/kyo-bad/items/47b96883144a5bf1cb1e
docker for windowsのpostgreSQLのコンテナはvolume周りに少々問題を抱えているらしい。
その為上記の記事に従い、docker-compose.ymlファイルの変更を行った。

また、volumeで指定されていた.envファイルに記述されている変数を用いるのではなく
直書きに変更し書いたpathの先頭の./を削除した。
これはdocker runコマンドで動作確認を行った際に-vオプションで./を使うと上手くいかないことがあったためである。

以上で問題は解決した。

